### PR TITLE
Sleep and retry on exceeding API call quota.

### DIFF
--- a/lib/WWW/Billomat.pm
+++ b/lib/WWW/Billomat.pm
@@ -8,7 +8,7 @@ use warnings;
 use Moose;
 
 use URI;
-use REST::Client;
+use WWW::Billomat::RESTClient;
 use Encode;
 
 use WWW::Billomat::Client;
@@ -64,7 +64,7 @@ has api_key => (
 
 has rest_client => (
     is => 'rw',
-    isa => 'REST::Client',
+    isa => 'WWW::Billomat::RESTClient',
     lazy_build => 1,
     handles => {
         response_code => 'responseCode',
@@ -120,7 +120,8 @@ set is:
 
 B<NOTE>: all methods return either undef or false in case of failure.
 To investigate error conditions, three methods are delegated to the
-underlying L<REST::Client> object:
+underlying L<WWW::Billomat::RESTClient> (which is a subclass of <REST::Client>)
+object:
 
 =over 4
 
@@ -522,7 +523,7 @@ sub create_invoice_item {
 sub _build_rest_client {
     my($self) = @_;
 
-    my $client = REST::Client->new(
+    my $client = WWW::Billomat::RESTClient->new(
         host => $self->base_url->as_string,
     );
     $client->addHeader(

--- a/lib/WWW/Billomat/RESTClient.pm
+++ b/lib/WWW/Billomat/RESTClient.pm
@@ -1,0 +1,66 @@
+package WWW::Billomat::RESTClient;
+
+use 5.010;
+
+use strict;
+use warnings;
+
+use base 'REST::Client';
+
+=head1 NAME
+
+WWW::Billomat::RESTClient - REST client for WWW::Billomat
+
+=head1 VERSION
+
+Version 0.01
+
+=cut
+
+our $VERSION = '0.01';
+
+=head1 SYNOPSIS
+
+Used by L<WWW::Billomat> internally.
+
+=head1 METHODS
+
+=head2 request
+
+Overridden from L<REST::Client/request>. Sleeps and retries if the quota on the
+number of API calls per time window is exceeded (see
+http://www.billomat.com/en/api/basics/rate-limiting).
+
+=cut
+
+sub request {
+    my $self = shift;
+
+    {
+        my $res = $self->next::method(@_);
+
+        if ($res->responseCode == 429) {
+            if ( !$res->responseHeader('X-Rate-Limit-Remaining') ) {
+                my $time_until_reset
+                    = $res->responseHeader('X-Rate-Limit-Reset') // time;
+
+                my $time_to_sleep = $time_until_reset - time;
+                $time_to_sleep = 10 if $time_to_sleep < 0;
+
+                warn "The quota on the number of API calls per time window is "
+                    . "exceeded (see "
+                    . "http://www.billomat.com/en/api/basics/rate-limiting). "
+                    . "Sleeping $time_to_sleep seconds before retrying.\n";
+
+                sleep $time_to_sleep;
+
+                redo;
+            }
+        }
+
+        return $res;
+    }
+}
+
+
+1; # End of WWW::Billomat::RESTClient


### PR DESCRIPTION
Billomat sets a limit on the number of REST API requests per each 15m time window, and if the client exceeds that then Billomat sends an error response which just breaks the app using WWW::Billomat. The time limit for unregistered apps (eg. a test account) is just 300req/15m which is very easy to exceed.

The changes in this pull request would add automatic detection and retry when the quota is exceeded.
